### PR TITLE
Set TTLs During Closure Execution

### DIFF
--- a/src/OffloadManager.php
+++ b/src/OffloadManager.php
@@ -208,6 +208,16 @@ class OffloadManager implements OffloadManagerInterface
 		if ($ttl_fresh || $ttl_stale) {
 			$result->then(function ($data) use ($key, $run, $ttl_fresh, $ttl_stale) {
 				if (!$run->isBad()) {
+					$run_ttl_fresh = $run->getTtlFresh();
+					if ($run_ttl_fresh !== null) {
+						$ttl_fresh = $run_ttl_fresh;
+					}
+
+					$run_ttl_stale = $run->getTtlStale();
+					if ($run_ttl_stale !== null) {
+						$ttl_stale = $run_ttl_stale;
+					}
+
 					$this->cache->set($key, $data, $ttl_fresh, $ttl_stale, $run->getCacheOptions());
 				}
 			});

--- a/src/OffloadRun.php
+++ b/src/OffloadRun.php
@@ -8,6 +8,10 @@ class OffloadRun
 	protected $bad = false;
 	/** @var array Additional cache options. */
 	protected $cache_options = [];
+	/** @var float|null Null values are ignored, number of seconds to cache value  */
+	protected $ttl_fresh;
+	/** @var float|null Null values are ignored, number of seconds set stale cache */
+	protected $ttl_stale;
 
 	/**
 	 * Set the result to be bad (meaning it won't get cached).
@@ -41,5 +45,37 @@ class OffloadRun
 	public function getCacheOptions()
 	{
 		return $this->cache_options;
+	}
+
+	/**
+	 * @return float|null The fresh TTL in seconds.
+	 */
+	public function getTtlFresh()
+	{
+		return $this->ttl_fresh;
+	}
+
+	/**
+	 * @param float|null $ttl_fresh The fresh TTL in seconds.
+	 */
+	public function setTtlFresh($ttl_fresh)
+	{
+		$this->ttl_fresh = $ttl_fresh;
+	}
+
+	/**
+	 * @return float|null The stale TTL in seconds.
+	 */
+	public function getTtlStale()
+	{
+		return $this->ttl_stale;
+	}
+
+	/**
+	 * @param float|null $ttl_stale The stale TTL in seconds.
+	 */
+	public function setTtlStale($ttl_stale)
+	{
+		$this->ttl_stale = $ttl_stale;
 	}
 }

--- a/tests/src/OffloadManagerMemoryTest.php
+++ b/tests/src/OffloadManagerMemoryTest.php
@@ -8,9 +8,9 @@ use Aol\Offload\OffloadManager;
 
 class OffloadManagerMemoryTest extends OffloadManagerTest
 {
-    protected function setUp()
-    {
-        $this->base_cache = new OffloadCacheMemory();
-        $this->manager = new OffloadManager($this->base_cache, new OffloadLockMemory());
-    }
+	protected function setUp()
+	{
+		$this->base_cache = new OffloadCacheMemory();
+		$this->manager = new OffloadManager($this->base_cache, new OffloadLockMemory());
+	}
 }

--- a/tests/src/OffloadManagerMockTest.php
+++ b/tests/src/OffloadManagerMockTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Aol\Offload\Tests;
+
+use Aol\Offload\Cache\OffloadCacheInterface;
+use Aol\Offload\Lock\OffloadLockInterface;
+use Aol\Offload\OffloadManager;
+use Aol\Offload\OffloadManagerCache;
+use Aol\Offload\OffloadResult;
+use Aol\Offload\OffloadRun;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class OffloadManagerMockTest extends TestCase
+{
+	/** @var OffloadManager */
+	private $offload_manager;
+
+	/** @var OffloadManagerCache|MockObject */
+	private $cache;
+
+	/** @var OffloadLockInterface|MockObject */
+	private $lock;
+
+	protected function setUp()
+	{
+		$this->offload_manager = new OffloadManager(
+			$this->getMock('Aol\Offload\Cache\OffloadCacheInterface'),
+			$this->getMock('Aol\Offload\Lock\OffloadLockInterface')
+		);
+
+		// This value isn't injected, manually "injecting" it with reflection.
+		$this->cache = $this->getMock('Aol\Offload\OffloadManagerCache', [], [], '', false);
+		$cache = new \ReflectionProperty($this->offload_manager, 'cache');
+		$cache->setAccessible(true);
+		$cache->setValue($this->offload_manager, $this->cache);
+	}
+
+	public function testRunSetTtls()
+	{
+		// Force Cache Miss
+		$this->cache->expects($this->once())
+			->method('get')
+			->willReturn(OffloadResult::miss());
+
+		// Set expected cache value and ttls
+		$this->cache->expects($this->once())
+			->method('set')
+			->with('my-key', ['hello' => 'world'], 14, 6, []);
+
+		$this->offload_manager->fetchCached('my-key', 60, function (OffloadRun $run) {
+			$run->setTtlFresh(14);
+			$run->setTtlStale(6);
+
+			return ['hello' => 'world'];
+		});
+	}
+}


### PR DESCRIPTION
Allows developers to set different TTLs based on the result of the cache look up.