### PR TITLE
Remove Test Namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,12 @@
 		"psr-4": {
 			"Aol\\Offload\\": "src/"
 		}
+	},
+	"autoload-dev": {
+		"files": [
+			"tests/src/Cache/OffloadCacheTest.php",
+			"tests/src/Lock/OffloadLockTest.php",
+			"tests/src/OffloadManagerTest.php"
+		]
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <phpunit
-	bootstrap="tests/bootstrap.php"
+	bootstrap="vendor/autoload.php"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-$loader = require __DIR__ . '/../vendor/autoload.php';
-$loader->setPsr4("Aol\\Offload\\Tests\\", __DIR__ . '/src');

--- a/tests/src/Cache/OffloadCacheMemcachedTest.php
+++ b/tests/src/Cache/OffloadCacheMemcachedTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Cache;
-
-use Aol\Offload\Cache\OffloadCacheMemcached;
+namespace Aol\Offload\Cache;
 
 class OffloadCacheMemcachedTest extends OffloadCacheTest
 {

--- a/tests/src/Cache/OffloadCacheMemoryTest.php
+++ b/tests/src/Cache/OffloadCacheMemoryTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Cache;
-
-use Aol\Offload\Cache\OffloadCacheMemory;
+namespace Aol\Offload\Cache;
 
 class OffloadCacheMemoryTest extends OffloadCacheTest
 {

--- a/tests/src/Cache/OffloadCacheRedisTest.php
+++ b/tests/src/Cache/OffloadCacheRedisTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Cache;
-
-use Aol\Offload\Cache\OffloadCacheRedis;
+namespace Aol\Offload\Cache;
 
 class OffloadCacheRedisTest extends OffloadCacheTest
 {

--- a/tests/src/Cache/OffloadCacheTest.php
+++ b/tests/src/Cache/OffloadCacheTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Cache;
-
-use Aol\Offload\Cache\OffloadCacheInterface;
+namespace Aol\Offload\Cache;
 
 abstract class OffloadCacheTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/src/Lock/OffloadLockBypassTest.php
+++ b/tests/src/Lock/OffloadLockBypassTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Lock;
-
-use Aol\Offload\Lock\OffloadLockBypass;
+namespace Aol\Offload\Lock;
 
 class OffloadLockBypassTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/src/Lock/OffloadLockMemcachedTest.php
+++ b/tests/src/Lock/OffloadLockMemcachedTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Lock;
-
-use Aol\Offload\Lock\OffloadLockMemcached;
+namespace Aol\Offload\Lock;
 
 class OffloadLockMemcachedTest extends OffloadLockTest
 {

--- a/tests/src/Lock/OffloadLockMemoryTest.php
+++ b/tests/src/Lock/OffloadLockMemoryTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Lock;
-
-use Aol\Offload\Lock\OffloadLockMemory;
+namespace Aol\Offload\Lock;
 
 class OffloadLockMemoryTest extends OffloadLockTest
 {

--- a/tests/src/Lock/OffloadLockRedisTest.php
+++ b/tests/src/Lock/OffloadLockRedisTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Lock;
-
-use Aol\Offload\Lock\OffloadLockRedis;
+namespace Aol\Offload\Lock;
 
 class OffloadLockRedisTest extends OffloadLockTest
 {

--- a/tests/src/Lock/OffloadLockTest.php
+++ b/tests/src/Lock/OffloadLockTest.php
@@ -1,8 +1,6 @@
 <?php
 
-namespace Aol\Offload\Tests\Lock;
-
-use Aol\Offload\Lock\OffloadLockInterface;
+namespace Aol\Offload\Lock;
 
 abstract class OffloadLockTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/src/OffloadManagerMemcachedTest.php
+++ b/tests/src/OffloadManagerMemcachedTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Aol\Offload\Tests;
+namespace Aol\Offload;
 
 use Aol\Offload\Cache\OffloadCacheMemcached;
 use Aol\Offload\Lock\OffloadLockMemcached;
-use Aol\Offload\OffloadManager;
 
 class OffloadManagerMemcachedTest extends OffloadManagerTest
 {

--- a/tests/src/OffloadManagerMemoryTest.php
+++ b/tests/src/OffloadManagerMemoryTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Aol\Offload\Tests;
+namespace Aol\Offload;
 
 use Aol\Offload\Cache\OffloadCacheMemory;
 use Aol\Offload\Lock\OffloadLockMemory;
-use Aol\Offload\OffloadManager;
 
 class OffloadManagerMemoryTest extends OffloadManagerTest
 {

--- a/tests/src/OffloadManagerMockTest.php
+++ b/tests/src/OffloadManagerMockTest.php
@@ -1,13 +1,8 @@
 <?php
 
-namespace Aol\Offload\Tests;
+namespace Aol\Offload;
 
-use Aol\Offload\Cache\OffloadCacheInterface;
 use Aol\Offload\Lock\OffloadLockInterface;
-use Aol\Offload\OffloadManager;
-use Aol\Offload\OffloadManagerCache;
-use Aol\Offload\OffloadResult;
-use Aol\Offload\OffloadRun;
 use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 

--- a/tests/src/OffloadManagerRedisTest.php
+++ b/tests/src/OffloadManagerRedisTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Aol\Offload\Tests;
+namespace Aol\Offload;
 
 use Aol\Offload\Cache\OffloadCacheRedis;
 use Aol\Offload\Lock\OffloadLockRedis;
-use Aol\Offload\OffloadManager;
 
 class OffloadManagerRedisTest extends OffloadManagerTest
 {

--- a/tests/src/OffloadManagerTest.php
+++ b/tests/src/OffloadManagerTest.php
@@ -1,14 +1,10 @@
 <?php
 
-namespace Aol\Offload\Tests;
+namespace Aol\Offload;
 
 use Aol\Offload\Cache\OffloadCacheInterface;
 use Aol\Offload\Deferred\OffloadDeferred;
 use Aol\Offload\Exceptions\OffloadDrainException;
-use Aol\Offload\OffloadManagerInterface;
-use Aol\Offload\OffloadManager;
-use Aol\Offload\OffloadResult;
-use Aol\Offload\OffloadRun;
 
 abstract class OffloadManagerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Moves tests to the same namespace as the implementations. This reduces the number of namespace inclusions per test.
Removes test/bootstrap infavor of vendor/autoload.php. Updates composer autoload to autoload 3 required files.