### PR TITLE
Prevent Blocking & Provide Access To Deferred

### DIFF
--- a/src/OffloadManager.php
+++ b/src/OffloadManager.php
@@ -170,7 +170,7 @@ class OffloadManager implements OffloadManagerInterface
 
             // If there is no data in cache or the data is stale and background fetch is turned off,
             // run the repopulate immediately and cache the results.
-            $data = $this->run($key, $repopulate, $options)->wait();
+            $data = $this->run($key, $repopulate, $options);
             $result = new OffloadResult($data, false, 0);
 
         } elseif ($stale) {

--- a/tests/src/OffloadManagerMockTest.php
+++ b/tests/src/OffloadManagerMockTest.php
@@ -14,9 +14,6 @@ class OffloadManagerMockTest extends TestCase
     /** @var OffloadManagerCache|MockObject */
     private $cache;
 
-    /** @var OffloadLockInterface|MockObject */
-    private $lock;
-
     protected function setUp()
     {
         $this->offload_manager = new OffloadManager(

--- a/tests/src/OffloadManagerTest.php
+++ b/tests/src/OffloadManagerTest.php
@@ -31,7 +31,7 @@ abstract class OffloadManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $result->getData());
         $this->assertTrue($result->isFromCache());
         $this->assertGreaterThanOrEqual($result->getExpireTime(), time());
-        $this->assertTrue($result->isStale(), 'asd');
+        $this->assertTrue($result->isStale());
     }
 
     public function testFetchCachedFresh()
@@ -42,6 +42,7 @@ abstract class OffloadManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($result->isFromCache());
         $result = $this->manager->fetch(__METHOD__, function () use ($data) { return $data; });
         $this->assertEquals($data, $result->getData());
+        $this->assertEquals($data, $result->getDeferred()->wait());
         $this->assertTrue($result->isFromCache());
         $this->assertTrue($result->getStaleTime() < 0);
         $this->assertFalse($result->isStale());
@@ -186,7 +187,10 @@ abstract class OffloadManagerTest extends \PHPUnit_Framework_TestCase
                 return $data;
             });
         });
+
+        $this->assertNull($this->base_cache->get(__METHOD__));
         $this->assertEquals($data, $result->getData());
+        $this->assertNotNull($this->base_cache->get(__METHOD__));
     }
 
     public function testRealDeferredAlreadyWaited()
@@ -200,6 +204,8 @@ abstract class OffloadManagerTest extends \PHPUnit_Framework_TestCase
             $defer->wait();
             return $defer;
         });
+
+        $this->assertNotNull($this->base_cache->get(__METHOD__));
         $this->assertEquals($data, $result->getData());
     }
 


### PR DESCRIPTION
When executing a ->fetch command where a deferred is returned, the response is blocked until the defer completes.
This removes that unnecessary wait call and defers the wait till the data is accessed in OffloadResult::getData.
It also provides access to the Deferred through OffloadResult::getDeferred