### PR TITLE
🚑 Declare tasks variable with empty array

### DIFF
--- a/src/OffloadManager.php
+++ b/src/OffloadManager.php
@@ -15,7 +15,7 @@ class OffloadManager implements OffloadManagerInterface
     /** @var OffloadLockInterface The lock. */
     protected $lock;
     /** @var callable[] An array of tasks to run on drain. */
-    protected $tasks;
+    protected $tasks = [];
     /** @var array The default options for this offload manager. */
     protected $default_options;
 


### PR DESCRIPTION
🚑 Declare tasks variable with empty array to avoid warning on hasWork() method when no tasks are set.